### PR TITLE
set specific python version for poetry-lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,8 +44,8 @@ repos:
     rev: '1.4.0'
     hooks:
       - id: poetry-check
-# Comment out due to error: Current Python version (3.11.1) is not allowed by the project (>=3.8,<3.11)
-#      - id: poetry-lock
+      - id: poetry-lock
+        language_version: python3.10
   - repo: https://github.com/AleksaC/circleci-cli-py
     rev: v0.1.25085
     hooks:


### PR DESCRIPTION
The pre-commit poetry-lock linter was failing because it 
selects it's own python version to use[1].  Change to tell
it to use a specific version.  hopefully this will fix the problem.

[1] https://github.com/pre-commit/pre-commit/issues/2586#issuecomment-1305994077